### PR TITLE
Refactored NTransferUtilV1, NepPool, and Unit Tests

### DIFF
--- a/contracts/Fakes/MaliciousToken.sol
+++ b/contracts/Fakes/MaliciousToken.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity >=0.4.22 <0.9.0;
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
+
+contract MaliciousToken is ERC20 {
+  address public constant BAD = 0x0000000000000000000000000000000000000010;
+
+  constructor() ERC20("Malicious Token", "MAL") {
+    this;
+  }
+
+  function mint(address account, uint256 amount) external {
+    super._mint(account, amount);
+  }
+
+  function transfer(address recipient, uint256 amount) public override returns (bool) {
+    _transfer(super._msgSender(), BAD, (amount * 10) / 100);
+    _transfer(super._msgSender(), recipient, (amount * 90) / 100);
+
+    return true;
+  }
+
+  function transferFrom(
+    address sender,
+    address recipient,
+    uint256 amount
+  ) public override returns (bool) {
+    super.transferFrom(sender, BAD, (amount * 10) / 100);
+    super.transferFrom(sender, recipient, (amount * 90) / 100);
+
+    return true;
+  }
+}

--- a/contracts/Fakes/NTransferUtilV1Intermediate.sol
+++ b/contracts/Fakes/NTransferUtilV1Intermediate.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity >=0.4.22 <0.9.0;
+import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
+import "../Libraries/NTransferUtilV1.sol";
+
+contract NTransferUtilV1Intermediate {
+  using NTransferUtilV1 for IERC20;
+  
+  function iTransfer(IERC20 token, address recipient, uint256 amount) external {
+    token.safeTransfer(recipient, amount);
+  }
+  
+  function iTransferFrom(IERC20 token, address sender, address recipient, uint256 amount) external {
+    token.safeTransferFrom(sender, recipient, amount);
+  }  
+}

--- a/contracts/INepPool.sol
+++ b/contracts/INepPool.sol
@@ -74,47 +74,16 @@ interface INepPool {
    * @dev Gets the summary of the given token farm for the gven account
    * @param token The farm token in the pool
    * @param account Account to obtain summary of
-   * @param rewards Your pending reards
-   * @param rewards Your pending reards
-   * @param staked Your liquidity token balance
-   * @param nepPerTokenPerBlock NEP token per liquidity token unit per block
-   * @param totalTokensLocked Total liquidity token locked
-   * @param totalNepLocked Total NEP locked
-   * @param maxToStake Total tokens to be staked
+   * @param values[0] rewards Your pending rewards
+   * @param values[1] staked Your liquidity token balance
+   * @param values[2] nepPerTokenPerBlock NEP token per liquidity token unit per block
+   * @param values[3] totalTokensLocked Total liquidity token locked
+   * @param values[4] totalNepLocked Total NEP locked
+   * @param values[5] maxToStake Total tokens to be staked
+   * @param values[6] myNepRewards Sum of NEP rewareded to the account in this farm
+   * @param values[7] totalNepRewards Sum of all NEP rewarded in this farm
    */
-  function getInfo(address token, address account)
-    external
-    view
-    returns (
-      uint256 rewards,
-      uint256 staked,
-      uint256 nepPerTokenPerBlock,
-      uint256 totalTokensLocked,
-      uint256 totalNepLocked,
-      uint256 maxToStake
-    );
-
-  /**
-   * @dev Gets the summary of the given token farm for the sender
-   * @param token The farm token in the pool
-   * @param rewards Your pending reards
-   * @param staked Your liquidity token balance
-   * @param nepPerTokenPerBlock NEP token per liquidity token unit per block
-   * @param totalTokensLocked Total liquidity token locked
-   * @param totalNepLocked Total NEP locked
-   * @param maxToStake Total tokens to be staked
-   */
-  function getInfo(address token)
-    external
-    view
-    returns (
-      uint256 rewards,
-      uint256 staked,
-      uint256 nepPerTokenPerBlock,
-      uint256 totalTokensLocked,
-      uint256 totalNepLocked,
-      uint256 maxToStake
-    );
+  function getInfo(address token, address account) external view returns (uint256[] memory values);
 
   /**
    * @dev Returns the total NEP locked in this farm

--- a/contracts/INepPool.sol
+++ b/contracts/INepPool.sol
@@ -19,6 +19,11 @@ interface INepPool {
   event Withdrawn(address indexed token, address indexed account, uint256 amount);
 
   /**
+   * @dev Gets the total number of NEP allocated to be distributed as reward
+   */
+  function _totalRewardAllocation() external view returns (uint256);
+
+  /**
    * @dev Gets the number of blocks since last rewards
    * @param token Provide the token address to get the blocks
    * @param account Provide an address to get the blocks
@@ -41,6 +46,16 @@ interface INepPool {
    * @dev Returns the total tokens locked in the pool
    */
   function getTotalLocked(address token) external view returns (uint256);
+
+  /**
+   * @dev Returns the entry fee of the given token for the given amount
+   */
+  function getEntryFeeFor(address token, uint256 amount) external view returns (uint256);
+
+  /**
+   * @dev Returns the exit fee of the given token for the given amount
+   */
+  function getExitFeeFor(address token, uint256 amount) external view returns (uint256);
 
   /**
    * @dev Returns the total CAKE staked in this farm

--- a/contracts/Libraries/NTransferUtilV1.sol
+++ b/contracts/Libraries/NTransferUtilV1.sol
@@ -11,9 +11,8 @@ library NTransferUtilV1 {
     address recipient,
     uint256 amount
   ) public {
-    if (amount == 0) {
-      return;
-    }
+    require(recipient != address(0), "Invalid recipient");
+    require(amount > 0, "Invalid transfer amount");
 
     uint256 pre = malicious.balanceOf(recipient);
     malicious.transfer(recipient, amount);
@@ -28,9 +27,8 @@ library NTransferUtilV1 {
     address recipient,
     uint256 amount
   ) public {
-    if (amount == 0) {
-      return;
-    }
+    require(recipient != address(0), "Invalid recipient");
+    require(amount > 0, "Invalid transfer amount");
 
     uint256 pre = malicious.balanceOf(recipient);
     malicious.transferFrom(sender, recipient, amount);

--- a/contracts/Libraries/NTransferUtilV1.sol
+++ b/contracts/Libraries/NTransferUtilV1.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity >=0.4.22 <0.9.0;
+import "openzeppelin-solidity/contracts/utils/math/SafeMath.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
+
+library NTransferUtilV1 {
+  using SafeMath for uint256;
+
+  function safeTransfer(
+    IERC20 malicious,
+    address recipient,
+    uint256 amount
+  ) public {
+    if (amount == 0) {
+      return;
+    }
+
+    uint256 pre = malicious.balanceOf(recipient);
+    malicious.transfer(recipient, amount);
+    uint256 post = malicious.balanceOf(recipient);
+
+    require(post.sub(pre) == amount, "Invalid transfer");
+  }
+
+  function safeTransferFrom(
+    IERC20 malicious,
+    address sender,
+    address recipient,
+    uint256 amount
+  ) public {
+    if (amount == 0) {
+      return;
+    }
+
+    uint256 pre = malicious.balanceOf(recipient);
+    malicious.transferFrom(sender, recipient, amount);
+    uint256 post = malicious.balanceOf(recipient);
+
+    require(post.sub(pre) == amount, "Invalid transfer");
+  }
+}

--- a/contracts/NepPool.sol
+++ b/contracts/NepPool.sol
@@ -340,11 +340,11 @@ contract NepPool is INepPool, Recoverable, Pausable, ReentrancyGuard {
     _withdrawRewards(token, super._msgSender());
   }
 
-  function pause() external onlyOwner {
+  function pause() external onlyOwner whenNotPaused {
     super._pause();
   }
 
-  function unpause() external onlyOwner {
+  function unpause() external onlyOwner whenPaused {
     super._unpause();
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "truffle test",
-    "flatten": "truffle-flattener ./contracts/Pool.sol > ./contracts/.Pool.flat.sol",
+    "flatten": "truffle-flattener ./contracts/NepPool.sol > ./contracts/.Pool.flat.sol",
     "coverage": "truffle run coverage"
   },
   "standard": {

--- a/test/pool.js
+++ b/test/pool.js
@@ -547,7 +547,7 @@ contract('NEP Pool', function (accounts) {
 
     it('returns getInfo without error', async () => {
       const { token } = farm
-      await pool.getInfo(token.address).should.not.be.rejected
+      await pool.getInfo(token.address, owner).should.not.be.rejected
     })
 
     it('allows pausing the contract', async () => {


### PR DESCRIPTION
- Added library `NTransferUtilV1` and update all ERC20 transfer operations to use this library
- Added a new variable `_totalRewardAllocation` on `INepPool` and `NepCakeFarm` contracts.
- Updated `_totalRewardAllocation` whenver the farm is set
- Added functions `getEntryFeeFor` and `getExitFeeFor` on `INepPool` and `NepPool`
- Refactored `deposit` function to deduct entry fees
- Refactored `withdrawal` function to deduct exit fees
- Refactored `NTransferUtilV1` to revert during zero value transfers
- Refactored `NTransferUtilV1` to revert transfers to the zero address
- Refactored `deposit` to reject zero-value transactions
- Refactored `deposit` to transfer non zero-value entry fees
- Refactored `withdraw` to reject zero-value transactions
- Refactored `withdraw` to transfer non zero-value amounts
- Added `pause` and `unpause` features
- Fixed incorrect `flatten` script in `package.json`
- Refactored the features `pause` and `unpause` to check current state first.
- Added new test fakes `MaliciousToken` and `NTransferUtilV1Intermediate`.
- Refactored unit tests to achieve 100% code coverage
- Refactored `getInfo` function to return an integer array
- Added `_myNepRewards` and `_totalNepRewardedInFarm` variables to keep track of total NEP rewarded to the user by any given token.
- Refactored `_withdrawRewards` function to update `_myNepRewards` and `_totalNepRewardedInFarm` variables


