### PR TITLE
Reward Allocation and Remaining NEP Rewards

### DIFF
--- a/contracts/INepPool.sol
+++ b/contracts/INepPool.sol
@@ -24,6 +24,18 @@ interface INepPool {
   function _totalRewardAllocation() external view returns (uint256);
 
   /**
+   * @dev Gets the number of NEP tokens in this farm allocated to be distributed as reward
+   * @param token Provide the token address to get the reward allocation
+   */
+  function _rewardAllocation(address token) external view returns (uint256);
+
+  /**
+   * @dev Gets the remaining number of NEP tokens in this farm to be distributed as reward
+   * @param token Provide the token address to get the remaining rewards
+   */
+  function _remainingNEPRewards(address token) external view returns (uint256);
+
+  /**
    * @dev Gets the number of blocks since last rewards
    * @param token Provide the token address to get the blocks
    * @param account Provide an address to get the blocks
@@ -82,6 +94,7 @@ interface INepPool {
    * @param values[5] maxToStake Total tokens to be staked
    * @param values[6] myNepRewards Sum of NEP rewareded to the account in this farm
    * @param values[7] totalNepRewards Sum of all NEP rewarded in this farm
+   * @param values[8] remainingNEPRewards Remaining NEP in this farm
    */
   function getInfo(address token, address account) external view returns (uint256[] memory values);
 

--- a/contracts/Libraries/NTransferUtilV1.sol
+++ b/contracts/Libraries/NTransferUtilV1.sol
@@ -2,22 +2,25 @@
 pragma solidity >=0.4.22 <0.9.0;
 import "openzeppelin-solidity/contracts/utils/math/SafeMath.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/utils/SafeERC20.sol";
 
 library NTransferUtilV1 {
   using SafeMath for uint256;
+  using SafeERC20 for IERC20;
 
   function safeTransfer(
     IERC20 malicious,
     address recipient,
     uint256 amount
-  ) public {
+  ) external {
     require(recipient != address(0), "Invalid recipient");
     require(amount > 0, "Invalid transfer amount");
 
     uint256 pre = malicious.balanceOf(recipient);
-    malicious.transfer(recipient, amount);
+    malicious.safeTransfer(recipient, amount);
     uint256 post = malicious.balanceOf(recipient);
 
+    // slither-disable-next-line incorrect-equality
     require(post.sub(pre) == amount, "Invalid transfer");
   }
 
@@ -26,14 +29,15 @@ library NTransferUtilV1 {
     address sender,
     address recipient,
     uint256 amount
-  ) public {
+  ) external {
     require(recipient != address(0), "Invalid recipient");
     require(amount > 0, "Invalid transfer amount");
 
     uint256 pre = malicious.balanceOf(recipient);
-    malicious.transferFrom(sender, recipient, amount);
+    malicious.safeTransferFrom(sender, recipient, amount);
     uint256 post = malicious.balanceOf(recipient);
 
+    // slither-disable-next-line incorrect-equality
     require(post.sub(pre) == amount, "Invalid transfer");
   }
 }

--- a/contracts/Recoverable.sol
+++ b/contracts/Recoverable.sol
@@ -9,6 +9,8 @@ abstract contract Recoverable is Ownable {
    */
   function recoverEther() external onlyOwner {
     address owner = super.owner();
+
+    // slither-disable-next-line arbitrary-send
     payable(owner).transfer(address(this).balance);
   }
 
@@ -21,6 +23,6 @@ abstract contract Recoverable is Ownable {
     IERC20 bep20 = IERC20(token);
 
     uint256 balance = bep20.balanceOf(address(this));
-    bep20.transfer(owner, balance);
+    require(bep20.transfer(owner, balance), "Transfer failed");
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
   },
   "scripts": {
     "test": "truffle test",
-    "flatten": "truffle-flattener ./contracts/NepPool.sol > ./contracts/.Pool.flat.sol",
-    "coverage": "truffle run coverage"
+    "flatten": "flatsol ./contracts/NepPool.sol > ./.flatsol/Pool.sol",
+    "coverage": "truffle run coverage",
+    "slither": "slither ."
   },
   "standard": {
     "env": [

--- a/slither.config.json
+++ b/slither.config.json
@@ -1,0 +1,10 @@
+{
+  "exclude_informational": true,
+  "exclude_low": true,
+  "exclude_medium": false,
+  "exclude_high": false,
+  "truffle_ignore_compile": false,
+  "disable_color": false,
+  "legacy_ast": false,
+  "filter_paths": "Fakes|Migrations.sol|openzeppelin"
+}


### PR DESCRIPTION
- Added `slither` package and configuration
- Added `_rewardAllocation` to keep track of NEP reward allocation per liquidity token
- Added `_remainingNEPRewards` to keep track of remaining NEP rewards per liquidity token
- Added `setMinStakingPeriodInBlocks` function to allow updating minimum staking period
- Refactored `deposit` function to move safeTransferFrom after updating the state variables
- Dropped payable keyword from the constructor
- Refactored `addLiquidity` to update `_rewardAllocation` and `_remainingNEPRewards` state variables
- Refactored `getInfo` to return `_rewardAllocation` and `_remainingNEPRewards`
- Updated `recoverToken` on `Recoverable` to throw if the `transfer` function does not return true
- Updated `NTransferUtilV1` functions to be external
- Refactored `NTransferUtilV1` to use OpenZeppelin `SafeERC20`